### PR TITLE
Added 'sort' to allowed query methods

### DIFF
--- a/app/mongo/lib/mongo_adaptor_server.rb
+++ b/app/mongo/lib/mongo_adaptor_server.rb
@@ -39,7 +39,7 @@ module Volt
       end
 
       def query(collection, query)
-        allowed_methods = %w(find skip limit)
+        allowed_methods = %w(find skip limit sort)
 
         cursor = @db[collection]
 


### PR DESCRIPTION
Was getting the '`sort` is not part of a valid query' error with volt-head from github, this small patch made sorting possible for me.
