### PR TITLE
Upgrade to the most recent Mongo Ruby driver version

### DIFF
--- a/app/mongo/lib/mongo_adaptor_server.rb
+++ b/app/mongo/lib/mongo_adaptor_server.rb
@@ -25,7 +25,7 @@ module Volt
           db
 
           true
-        rescue ::Mongo::Error => e
+        rescue ::Mongo::ConnectionFailure => e
           false
         end
       end

--- a/app/mongo/lib/mongo_adaptor_server.rb
+++ b/app/mongo/lib/mongo_adaptor_server.rb
@@ -25,7 +25,7 @@ module Volt
           db
 
           true
-        rescue ::Mongo::ConnectionFailure => e
+        rescue ::Mongo::Error => e
           false
         end
       end

--- a/volt-mongo.gemspec
+++ b/volt-mongo.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'mongo', '~> 3.0'
+  spec.add_dependency 'mongo', '~> 2.2.0'
   spec.add_development_dependency "rake"
 end

--- a/volt-mongo.gemspec
+++ b/volt-mongo.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'mongo', '~> 1.12'
+  spec.add_dependency 'mongo', '~> 1.12.0'
   spec.add_development_dependency "rake"
 end

--- a/volt-mongo.gemspec
+++ b/volt-mongo.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'mongo', '~> 1.9.0'
+  spec.add_dependency 'mongo', '~> 3.0'
   spec.add_development_dependency "rake"
 end

--- a/volt-mongo.gemspec
+++ b/volt-mongo.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'mongo', '~> 2.1.1'
+  spec.add_dependency 'mongo', '~> 1.12'
   spec.add_development_dependency "rake"
 end

--- a/volt-mongo.gemspec
+++ b/volt-mongo.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'mongo', '~> 2.2.0'
+  spec.add_dependency 'mongo', '~> 2.1.1'
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
`volt-mongo` is using an old version of the Mongo Ruby driver. Unfortunately, this has recently caused problems with services like MongoLabs since they've upgraded to Mongo 3.x, which means we need a newer driver version for this component to properly work with such services.

However, I've noticed that `volt-mongo` is using code specific to `mongo` 1.9.x, such as `Mongo::ConnectionFailure`. This obviously needs to be reworked for Volt apps to work with Mongo, and I suspect that there is other code in here that needs to be reworked as well for compatibility with newer versions of Mongo's Ruby driver.

Any thoughts @ryanstout?
