### PR TITLE
Mongo 3.2 compatibility

### DIFF
--- a/app/mongo/lib/mongo_adaptor_server.rb
+++ b/app/mongo/lib/mongo_adaptor_server.rb
@@ -66,7 +66,7 @@ module Volt
         rescue => error
           # Really mongo client?
           msg = error.message
-          if (msg[/^E11000/] || msg[/^insertDocument :: caused by :: 11000 E11000/]) && msg['$_id_']
+          if (msg[/^E11000/] || msg[/^insertDocument :: caused by :: 11000 E11000/]) && msg['_id_']
             # Update because the id already exists
             update_values = values.dup
             id = update_values.delete('_id')


### PR DESCRIPTION
Removed $ from error string to match Mongo 3.2 errors.  Mongo 3.2 error looks like:

"E11000 duplicate key error collection: my_database.my_collection index: _id_ dup key: { : \"c1793628f6d9be0c0b030193\" } (11000)"
